### PR TITLE
PLAT-9652: tmpl: fix link tag usage in see tags

### DIFF
--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -61,7 +61,7 @@ var self = this;
     <dt class="tag-see">See:</dt>
     <dd class="tag-see">
         <ul><?js see.forEach(function(s) { ?>
-            <li><?js= self.linkto(s) ?></li>
+            <li><?js= s.includes('@link') ? s : self.linkto(s) ?></li>
         <?js }); ?></ul>
     </dd>
     <?js } ?>


### PR DESCRIPTION
When using an `@link` tag inside an `@see` tag, if the link path is in the format `module:<path>`, the template doesn't parse it correctly, so it ends up like this:

<img width="418" alt="Screenshot 2024-10-22 at 17 32 41" src="https://github.com/user-attachments/assets/d2813363-306c-437e-b37a-b2b5359e5b38">

The problem is the full text is being passed to `linkto` instead of just the path. It slips through all the conditional checks and reaches the end `return` statement, which tries to convert it to a short name using `getShortName`, but this ends up splitting it by the colon after `module` and returning the popped result.

This PR checks if the `@see` text includes `@link` and uses the full link text directly instead of passing it to `linkto`.

Testing this change locally will require updating the template package code in your core repo's `node_modules`, and adding an `@see` tag somewhere as described above. For example, in `base/browser.js`:

```js
/**
 * Whether the current browser is on a mobile device or not
 * @see {@link module:base/browser}
 * @type {boolean}
 */
export const isTouchDevice =
    touchParam && ['false', 'true'].includes(touchParam)
        ? touchParam == 'true'
        : mobile || !!navigator.maxTouchPoints; //The maxTouchPoints test covers Edge browsers on windows tablets
```

This becomes important in [enh/PLAT-9652_fix_api_docs_links](https://github.com/IQGeo/myworld-product-core/tree/enh/PLAT-9652_fix_api_docs_links) where I've added `@see` tags with `@link`, and updated `jsdoc-plugin-typescript` to include this change: https://github.com/openlayers/jsdoc-plugin-typescript/pull/66.
