### PR TITLE
PLAT-9950: Fix bracket array type parsing and add Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 4,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@iqgeo/jsdoc-template",
+    "name": "jsdoc-template",
     "version": "2.6.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@iqgeo/jsdoc-template",
+            "name": "jsdoc-template",
             "version": "2.6.2",
             "license": "MIT",
             "dependencies": {
@@ -17,6 +17,7 @@
                 "less": "^2.7.1",
                 "less-plugin-clean-css": "^1.5.1",
                 "npm-run-all": "^4.1.5",
+                "prettier": "^3.3.3",
                 "rimraf": "^2.5.2",
                 "uglify-js": "^2.6.2",
                 "watch": "^1.0.2"
@@ -1330,6 +1331,22 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/promise": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "less": "^2.7.1",
         "less-plugin-clean-css": "^1.5.1",
         "npm-run-all": "^4.1.5",
+        "prettier": "^3.3.3",
         "rimraf": "^2.5.2",
         "uglify-js": "^2.6.2",
         "watch": "^1.0.2"

--- a/publish.js
+++ b/publish.js
@@ -21,7 +21,6 @@ var template = require('jsdoc/template'),
         '.gif': 'image/gif'
     };
 
-
 /**
  * Copied from https://github.com/jsdoc/jsdoc/blob/main/packages/jsdoc/lib/jsdoc/util/templateHelper.js
  * Modified to call our own `linkto` to shorten names.
@@ -31,23 +30,23 @@ var template = require('jsdoc/template'),
  * @param {string} cssClass The css class.
  * @return {Array} The returns.
  */
-function getSignatureReturns({yields, returns}, cssClass) {
+function getSignatureReturns({ yields, returns }, cssClass) {
     let returnTypes = [];
-  
+
     if (yields || returns) {
-      (yields || returns).forEach((r) => {
-        if (r && r.type && r.type.names) {
-          if (!returnTypes.length) {
-            returnTypes = r.type.names;
-          }
-        }
-      });
+        (yields || returns).forEach(r => {
+            if (r && r.type && r.type.names) {
+                if (!returnTypes.length) {
+                    returnTypes = r.type.names;
+                }
+            }
+        });
     }
-  
+
     if (returnTypes && returnTypes.length) {
-      returnTypes = returnTypes.map((r) => linkto(r, '', cssClass));
+        returnTypes = returnTypes.map(r => linkto(r, '', cssClass));
     }
-  
+
     return returnTypes;
 }
 

--- a/publish.js
+++ b/publish.js
@@ -108,7 +108,7 @@ function linkto(longname, linkText, cssClass, fragmentId) {
     if (match) {
         return (
             linkto(match[1], '', cssClass, fragmentId) +
-            '<' +
+            '.&lt;' +
             linkto(match[2], '', cssClass, fragmentId) +
             '>'
         );


### PR DESCRIPTION
## Description

Some JSDoc types that use bracket syntax (`Type[]` instead of `Array<Type>`) aren't parsed correctly. Turns out angle brackets aren't being escaped in some cases, so the types are being treated as HTML tags. This PR replaces them with `&lt;` entities.

Most of the changes are from adding Prettier, so you can check the second commit to see the relevant change.

To test the changes:
1. Manually add the change in `node_modules`
2. Build the API docs
3. Search `\[\](?!;)` in VSCode to find instances (you'll still get quite a few unrelated results, but easy enough to filter through)
4. Check the output in the JS API docs

## Related Issue

https://iqgeo.atlassian.net/browse/PLAT-9950

## Changes Made

- Add Prettier
- Escape `<` with `&lt;`