### PR TITLE
fix: include typedefs when there's no default export

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -388,10 +388,6 @@ function buildNav(members, conf) {
         }
     });
     members.modules.forEach(function (v) {
-        const classes = find({
-            kind: 'class',
-            memberof: v.longname
-        });
         const members = find({
             kind: 'member',
             memberof: v.longname
@@ -408,9 +404,10 @@ function buildNav(members, conf) {
             kind: 'event',
             memberof: v.longname
         });
-        // Only add modules that contain more than just classes with their
-        // associated Options typedef
-        if (typedefs.length > classes.length || members.length + methods.length > 0) {
+
+        // Only include modules with at least one symbol.
+        // Classes get their own page, so they don't need to be considered here.
+        if (typedefs.length || members.length || methods.length || events.length) {
             nav.push({
                 type: 'module',
                 longname: v.longname,


### PR DESCRIPTION
This PR fixes a bug where typedefs aren't included if there's no default export in the file.

JSDoc considers typedefs as "global" when there's no default export for some reason. To associate them with the correct modules, we have to get all typedef symbols with `memberof: undefined`, and match them by filename to the module they belong to.

I've also made it so modules are included in the nav if they have at least one symbol of any kind. They're currently only included if the module has more typedefs than classes or if they have at least one member or method.

To test these changes:

1. In core, switch to the `enh/PLAT-10894_display_crs` branch
2. Go to `WebApps/myworldapp/node_modules/jsdoc-template/publish.js`
3. Copy and paste the contents of `publish.js` from this PR
4. Run the `Build JS API docs` task (takes a couple minutes)
5. Go to `http://localhost:81/doc_file/en/JSApiDoc/index.html`
6. Find `base/displayCRS` in the nav with the `DisplayCRSSettings` typedef as its only symbol 