### PR TITLE
navigation: moved navigation into a reusable javascript module

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -393,6 +393,7 @@ function buildNav(members, conf) {
                 longname: v.longname,
                 prettyname: getPrettyName(v),
                 name: v.name,
+                url: helper.longnameToUrl[v.longname],
                 module: find({
                     kind: 'module',
                     longname: v.memberof
@@ -400,20 +401,53 @@ function buildNav(members, conf) {
                 members: find({
                     kind: 'member',
                     memberof: v.longname
+                }).map(function(member) {
+                    return {
+                        longname: member.longname,
+                        name: member.name,
+                        url: helper.longnameToUrl[member.longname],
+                        inherited: member.inherited,
+                        inherits: member.inherits,
+                        deprecated: member.deprecated
+                    };
                 }),
                 methods: find({
                     kind: 'function',
                     memberof: v.longname
+                }).map(function(method) {
+                    return {
+                        longname: method.longname,
+                        name: method.name,
+                        url: helper.longnameToUrl[method.longname],
+                        inherited: method.inherited,
+                        inherits: method.inherits,
+                        deprecated: method.deprecated
+                    };
                 }),
                 typedefs: find({
                     kind: 'typedef',
                     memberof: v.longname
+                }).map(function(typedef) {
+                    return {
+                        longname: typedef.longname,
+                        name: typedef.name,
+                        url: helper.longnameToUrl[typedef.longname]
+                    };
                 }),
                 fires: v.fires,
                 events: find({
                     kind: 'event',
                     memberof: v.longname
-                })
+                }).map(function(event) {
+                    return {
+                        longname: event.longname,
+                        name: event.name,
+                        url: helper.longnameToUrl[event.longname],
+                        inherited: event.inherited,
+                        inherits: event.inherits
+                    };
+                }),
+                deprecated: v.deprecated
             });
         }
     });
@@ -443,11 +477,45 @@ function buildNav(members, conf) {
                 longname: v.longname,
                 prettyname: getPrettyName(v),
                 name: v.name,
-                members: members,
-                methods: methods,
-                typedefs: typedefs,
+                url: helper.longnameToUrl[v.longname],
+                members: members.map(function(member) {
+                    return {
+                        longname: member.longname,
+                        name: member.name,
+                        url: helper.longnameToUrl[member.longname],
+                        inherited: member.inherited,
+                        inherits: member.inherits,
+                        deprecated: member.deprecated
+                    };
+                }),
+                methods: methods.map(function(method) {
+                    return {
+                        longname: method.longname,
+                        name: method.name,
+                        url: helper.longnameToUrl[method.longname],
+                        inherited: method.inherited,
+                        inherits: method.inherits,
+                        deprecated: method.deprecated
+                    };
+                }),
+                typedefs: typedefs.map(function(typedef) {
+                    return {
+                        longname: typedef.longname,
+                        name: typedef.name,
+                        url: helper.longnameToUrl[typedef.longname]
+                    };
+                }),
                 fires: v.fires,
-                events: events
+                events: events.map(function(event) {
+                    return {
+                        longname: event.longname,
+                        name: event.name,
+                        url: helper.longnameToUrl[event.longname],
+                        inherited: event.inherited,
+                        inherits: event.inherits
+                    };
+                }),
+                deprecated: v.deprecated
             });
         }
     });
@@ -676,6 +744,14 @@ exports.publish = function (taffyData, opts, tutorials) {
 
     // This needs to be done after attaching module symbols, so they're included in the nav
     view.nav = buildNav(members, conf);
+
+    // Generate navigation.json file for shared navigation
+    var navData = {
+        nav: view.nav,
+        applicationName: env.conf.templates.applicationName || 'Documentation'
+    };
+    var navPath = path.join(outdir, 'navigation.json');
+    fs.writeFileSync(navPath, JSON.stringify(navData, null, 2), 'utf8');
 
     // only output pretty-printed source files if requested; do this before generating any other
     // pages, so the other pages can link to the source files

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,72 +1,84 @@
 $(function () {
+    
+    function initializeNavigation() {
+        var $nav = $('.navigation');
+        var $list = $nav.find('.list');
+        var $search = $('.search');
 
-    var $nav = $('.navigation');
-    var $list = $nav.find('.list');
-    var $search = $('.search');
+        // Search input
+        $('#search').on('keyup', function (e) {
+            var value = this.value.trim();
+            if (value) {
+                var regexp = new RegExp(value, 'i');
+                $nav.addClass('searching')
+                    .removeClass('not-searching')
+                    .find('li, .itemMembers')
+                    .removeClass('match');
 
-    // Search input
-    $('#search').on('keyup', function (e) {
-        var value = this.value.trim();
-        if (value) {
-            var regexp = new RegExp(value, 'i');
-            $nav.addClass('searching')
-                .removeClass('not-searching')
-                .find('li, .itemMembers')
-                .removeClass('match');
+                $nav.find('li').each(function (i, v) {
+                    var $item = $(v);
+                    if ($item.data('name') && regexp.test($item.data('name'))) {
+                        $item.addClass('match');
+                        $item.closest('.itemMembers').addClass('match');
+                        $item.closest('.item').addClass('match');
+                    }
+                });
+            } else {
+                $nav.removeClass('searching')
+                    .addClass('not-searching')
+                    .find('.item, .itemMembers')
+                    .removeClass('match');
+            }
+            $list.scrollTop(0);
+        });
 
-            $nav.find('li').each(function (i, v) {
-                var $item = $(v);
-                if ($item.data('name') && regexp.test($item.data('name'))) {
-                    $item.addClass('match');
-                    $item.closest('.itemMembers').addClass('match');
-                    $item.closest('.item').addClass('match');
-                }
+        $('#menuToggle').click(function() {
+            $list.toggleClass('show');
+            $search.toggleClass('show');
+        });
+
+        // Show an item related a current documentation automatically
+        $nav.addClass('not-searching');
+        var filename = $('.page-title').data('filename').replace(/\.[a-z]+$/, '');
+        var $currentItem = $nav.find('a[href*="' + filename + '"]:eq(0)').closest('.item');
+
+        if ($currentItem.length) {
+            // if a child then show the top level parent and highlight the
+            // current item.
+            if ($currentItem.parents('.children').length) {
+                $currentItem.addClass('current');
+                // need to make all children not current
+                $currentItem.find('li.item').addClass('notCurrent');
+                $currentItem = $currentItem.parents('ul.list>li.item');
+            }
+            $currentItem
+                .remove()
+                .prependTo($list)
+                .addClass('current');
+        }
+
+        // disqus code
+        if (config.disqus) {
+            $(window).on('load', function () {
+                var disqus_shortname = config.disqus; // required: replace example with your forum shortname
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                var s = document.createElement('script'); s.async = true;
+                s.type = 'text/javascript';
+                s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+                document.getElementsByTagName('BODY')[0].appendChild(s);
             });
-        } else {
-            $nav.removeClass('searching')
-                .addClass('not-searching')
-                .find('.item, .itemMembers')
-                .removeClass('match');
         }
-        $list.scrollTop(0);
-    });
-
-    $('#menuToggle').click(function() {
-        $list.toggleClass('show');
-        $search.toggleClass('show');
-    });
-
-    // Show an item related a current documentation automatically
-    $nav.addClass('not-searching');
-    var filename = $('.page-title').data('filename').replace(/\.[a-z]+$/, '');
-    var $currentItem = $nav.find('a[href*="' + filename + '"]:eq(0)').closest('.item');
-
-    if ($currentItem.length) {
-        // if a child then show the top level parent and highlight the
-        // current item.
-        if ($currentItem.parents('.children').length) {
-            $currentItem.addClass('current');
-            // need to make all children not current
-            $currentItem.find('li.item').addClass('notCurrent');
-            $currentItem = $currentItem.parents('ul.list>li.item');
-        }
-        $currentItem
-            .remove()
-            .prependTo($list)
-            .addClass('current');
     }
 
-    // disqus code
-    if (config.disqus) {
-        $(window).on('load', function () {
-            var disqus_shortname = config.disqus; // required: replace example with your forum shortname
-            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
-            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-            var s = document.createElement('script'); s.async = true;
-            s.type = 'text/javascript';
-            s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
-            document.getElementsByTagName('BODY')[0].appendChild(s);
+    // Initialize navigation when it's loaded, or immediately if already available
+    if ($('.navigation').length > 0) {
+        initializeNavigation();
+    } else {
+        // Wait for navigation to be loaded
+        document.addEventListener('navigationLoaded', function() {
+            initializeNavigation();
         });
     }
 });

--- a/src/scripts/navigation-loader.js
+++ b/src/scripts/navigation-loader.js
@@ -1,0 +1,333 @@
+/**
+ * Navigation loader for shared menu system
+ * Loads navigation data from navigation.json and renders it dynamically
+ */
+(function() {
+    'use strict';
+
+    var NavigationLoader = {
+        /**
+         * Helper function to get short name from longname
+         */
+        getShortName: function(longname) {
+            if (!longname.includes('module:')) {
+                return longname;
+            }
+            if (longname.includes('|')) {
+                return longname;
+            }
+            if (longname.includes('<')) {
+                return longname;
+            }
+            return longname.split(/[\~\.#\:]/).pop();
+        },
+
+        /**
+         * Creates a link to a documentation page
+         */
+        linkto: function(item, text, cssClass, fragmentId) {
+            text = text || item.name || this.getShortName(item.longname);
+            
+            var url = item.url || (item.longname + '.html');
+            if (fragmentId) {
+                url += '#' + fragmentId;
+            }
+            var classAttr = cssClass ? ' class="' + cssClass + '"' : '';
+            return '<a href="' + url + '"' + classAttr + '>' + text + '</a>';
+        },
+
+        /**
+         * Creates a tutorial link
+         */
+        tutoriallink: function(tutorial) {
+            return '<em class="disabled">Tutorial: ' + tutorial + '</em>';
+        },
+
+        /**
+         * Determines if an item can be styled as namespace
+         */
+        canStyleAsNamespace: function(item) {
+            return item.type === 'namespace' || item.type === 'module';
+        },
+
+        /**
+         * Renders a navigation item
+         */
+        renderItem: function(item) {
+            var self = this;
+            var html = '';
+            var canStyle = this.canStyleAsNamespace(item);
+            var deprecatedClass = item.deprecated ? ' status-deprecated' : '';
+            
+            html += '<li class="item' + deprecatedClass + '" data-name="' + 
+                    (item.type === 'tutorial' ? 'tutorial-' : '') + item.longname + '">';
+            
+            html += '<span class="title' + (canStyle ? ' namespace' : '') + deprecatedClass + '">';
+            
+            if (canStyle) {
+                var iconClass = (item.longname === 'global') ? 'globe' : 'folder-open';
+                html += '<span class="namespaceTag"><span class="glyphicon glyphicon-' + iconClass + '"></span></span>';
+            } else {
+                html += '<span class="namespaceTag"><span class="glyphicon glyphicon-minus"></span></span>';
+            }
+
+            if (item.type === 'module') {
+                html += this.linkto(item, item.name);
+            } else if (item.type === 'tutorial') {
+                html += '<span class="namespaceTag"><span class="glyphicon glyphicon-education"></span></span>';
+                html += this.tutoriallink(item.longname);
+            } else {
+                var displayName = item.longname === 'global' ? 'Global' : item.longname.replace(/^module:/, '');
+                html += this.linkto(item, displayName);
+            }
+
+            html += '</span>';
+
+            // Render members
+            if (item.members && item.members.length) {
+                html += '<ul class="members itemMembers">';
+                html += '<span class="subtitle">Members</span>';
+                item.members.forEach(function(member) {
+                    var parentClass = (!member.inherited && !member.inherits) ? ' parent' : '';
+                    var memberDeprecated = member.deprecated ? ' status-deprecated' : '';
+                    html += '<li class="' + parentClass + memberDeprecated + '" data-name="' + member.longname + '">';
+                    html += self.linkto(member, member.name);
+                    html += '</li>';
+                });
+                html += '</ul>';
+            }
+
+            // Render typedefs
+            if (item.typedefs && item.typedefs.length) {
+                html += '<ul class="typedefs itemMembers">';
+                html += '<span class="subtitle">Typedefs</span>';
+                item.typedefs.forEach(function(typedef) {
+                    html += '<li class="parent" data-name="' + typedef.longname + '">';
+                    html += self.linkto(typedef, typedef.name);
+                    html += '</li>';
+                });
+                html += '</ul>';
+            }
+
+            // Render interfaces
+            if (item.interfaces && item.interfaces.length) {
+                html += '<ul class="typedefs itemMembers">';
+                html += '<span class="subtitle">Interfaces</span>';
+                item.interfaces.forEach(function(iface) {
+                    html += '<li class="parent" data-name="' + iface.longname + '">';
+                    html += self.linkto(iface, iface.name);
+                    html += '</li>';
+                });
+                html += '</ul>';
+            }
+
+            // Render methods
+            if (item.methods && item.methods.length) {
+                html += '<ul class="methods itemMembers">';
+                html += '<span class="subtitle">Methods</span>';
+                item.methods.forEach(function(method) {
+                    var parentClass = (!method.inherited && !method.inherits) ? ' parent' : '';
+                    var methodDeprecated = method.deprecated ? ' status-deprecated' : '';
+                    html += '<li class="' + parentClass + methodDeprecated + '" data-name="' + method.longname + '">';
+                    html += self.linkto(method, method.name);
+                    html += '</li>';
+                });
+                html += '</ul>';
+            }
+
+            // Render events
+            if (item.events && item.events.length) {
+                html += '<ul class="events itemMembers">';
+                html += '<span class="subtitle">Events</span>';
+                item.events.forEach(function(event) {
+                    var parentClass = (!event.inherited && !event.inherits) ? ' parent' : '';
+                    html += '<li class="' + parentClass + '" data-name="' + event.longname + '">';
+                    html += self.linkto(event, event.name);
+                    html += '</li>';
+                });
+                html += '</ul>';
+            }
+
+            // Render children (recursive)
+            if (item.children && item.children.length) {
+                html += '<ul class="children itemMembers">';
+                html += '<span class="subtitle"></span>';
+                item.children.forEach(function(child) {
+                    html += self.renderItem(child);
+                });
+                html += '</ul>';
+            }
+
+            html += '</li>';
+            return html;
+        },
+
+        /**
+         * Renders the complete navigation
+         */
+        renderNavigation: function(navData) {
+            var html = '';
+            html += '<div class="navigation">';
+            html += '<h3 class="applicationName"><a href="index.html">' + navData.applicationName + '</a></h3>';
+            html += '<button id="menuToggle" class="btn btn-link btn-lg menu-toggle">';
+            html += '<span class="glyphicon glyphicon-menu-hamburger"></span>';
+            html += '</button>';
+            html += '<div class="search">';
+            html += '<input id="search" type="text" class="form-control input-md" placeholder="Search...">';
+            html += '</div>';
+            html += '<ul class="list">';
+
+            var self = this;
+            navData.nav.forEach(function(item) {
+                html += self.renderItem(item);
+            });
+
+            html += '</ul>';
+            html += '</div>';
+            return html;
+        },
+
+        /**
+         * Gets the relative path to navigation.json from the current page
+         */
+        getNavigationPath: function() {
+            return 'navigation.json';
+        },
+
+        /**
+         * Loads navigation data and renders it
+         */
+        loadNavigation: function() {
+            var self = this;
+            var navPath = this.getNavigationPath();
+            
+            console.log('Loading navigation from:', navPath);
+            
+            // Try to use fetch if available, otherwise fall back to XMLHttpRequest
+            if (typeof fetch !== 'undefined') {
+                fetch(navPath)
+                    .then(function(response) {
+                        console.log('Navigation response:', response.status);
+                        if (!response.ok) {
+                            throw new Error('Failed to load navigation data: ' + response.status);
+                        }
+                        return response.json();
+                    })
+                    .then(function(navData) {
+                        console.log('Navigation data loaded:', navData);
+                        self.injectNavigation(navData);
+                    })
+                    .catch(function(error) {
+                        console.error('Error loading navigation:', error);
+                    });
+            } else {
+                // Fallback for older browsers
+                var xhr = new XMLHttpRequest();
+                xhr.open('GET', navPath, true);
+                xhr.onreadystatechange = function() {
+                    if (xhr.readyState === 4) {
+                        console.log('XHR response:', xhr.status);
+                        if (xhr.status === 200) {
+                            try {
+                                var navData = JSON.parse(xhr.responseText);
+                                console.log('Navigation data loaded via XHR:', navData);
+                                self.injectNavigation(navData);
+                            } catch (e) {
+                                console.error('Error parsing navigation data:', e);
+                            }
+                        } else {
+                            console.error('Failed to load navigation data:', xhr.status);
+                        }
+                    }
+                };
+                xhr.send();
+            }
+        },
+
+        /**
+         * Injects the navigation HTML into the page
+         */
+        injectNavigation: function(navData) {
+            console.log('Injecting navigation...');
+            var navigationHtml = this.renderNavigation(navData);
+            var container = document.getElementById('navigation-container');
+            console.log('Navigation container found:', !!container);
+            if (container) {
+                container.innerHTML = navigationHtml;
+                console.log('Navigation HTML injected');
+                
+                // Highlight and move current page to top
+                this.highlightCurrentPage();
+                
+                // Trigger a custom event to let other scripts know navigation is loaded
+                var event = new CustomEvent('navigationLoaded');
+                document.dispatchEvent(event);
+            } else {
+                console.error('Navigation container not found');
+            }
+        },
+
+        /**
+         * Highlights the current page in navigation and moves it to top
+         */
+        highlightCurrentPage: function() {
+            var nav = document.querySelector('.navigation');
+            var list = nav.querySelector('.list');
+            if (!nav || !list) return;
+
+            // Get current page filename from page title or URL
+            var pageTitle = document.querySelector('.page-title');
+            var filename = '';
+            
+            if (pageTitle && pageTitle.dataset.filename) {
+                filename = pageTitle.dataset.filename.replace(/\.[a-z]+$/, '');
+            } else {
+                // Fallback: extract from current URL
+                var path = window.location.pathname;
+                filename = path.substring(path.lastIndexOf('/') + 1).replace('.html', '');
+            }
+
+            if (filename) {
+                // Find the navigation item that matches the current page
+                var currentItem = nav.querySelector('a[href*="' + filename + '"]');
+                if (currentItem) {
+                    var itemElement = currentItem.closest('.item');
+                    if (itemElement) {
+                        // If this is a child item, highlight it and expand parent
+                        if (itemElement.closest('.children')) {
+                            itemElement.classList.add('current');
+                            // Make all children not current except this one
+                            var siblings = itemElement.parentElement.querySelectorAll('li.item');
+                            siblings.forEach(function(sibling) {
+                                if (sibling !== itemElement) {
+                                    sibling.classList.add('notCurrent');
+                                }
+                            });
+                            // Find the top-level parent
+                            var topParent = itemElement.closest('.list > .item');
+                            if (topParent) {
+                                itemElement = topParent;
+                            }
+                        }
+                        
+                        // Move to top and highlight
+                        itemElement.classList.add('current');
+                        list.insertBefore(itemElement, list.firstChild);
+                    }
+                }
+            }
+        }
+    };
+
+    // Auto-load navigation when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function() {
+            NavigationLoader.loadNavigation();
+        });
+    } else {
+        NavigationLoader.loadNavigation();
+    }
+
+    // Export for use in other scripts
+    window.NavigationLoader = NavigationLoader;
+})();

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -54,7 +54,7 @@
 </head>
 <body>
 <div id="wrap" class="clearfix">
-    <?js= this.partial('navigation.tmpl', this) ?>
+    <nav id="navigation-container"></nav>
     <div class="main">
         <h1 class="page-title" data-filename="<?js= filename ?>"><?js= title ?></h1>
         <?js= content ?>


### PR DESCRIPTION
The current template was including the entire menu along with scripts for it in each page resulting in page sizes of 2MG. For an app with 800+ files, we're looking at 1.6 GB in size.

This change brings the navigation into a separate javascript module rather than defined inline. With this change, the size of the platform JsAPIDocs went from 1.6GB to 25MG.

The change is needed to limit the size of our generated documentation to allow us to work with size constraints in GitHub pages.